### PR TITLE
Ajout d'un écran appareil photo

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -76,4 +76,5 @@ yarn-error.*
 # typescript
 *.tsbuildinfo
 
-# @end expo-cli
+# Jest snapshots
+components/__tests__/__snapshots__/

--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -54,6 +54,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="camera"
+        options={{
+          title: 'Camera',
+          tabBarIcon: ({ color }) => <TabBarIcon name="camera" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/app/(tabs)/camera.tsx
+++ b/app/app/(tabs)/camera.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View, Image } from 'react-native';
+import { Camera, CameraCapturedPicture } from 'expo-camera';
+import * as FileSystem from 'expo-file-system';
+
+export default function CameraScreen() {
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
+  const [photoUri, setPhotoUri] = useState<string | null>(null);
+  const cameraRef = useRef<Camera | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await Camera.requestCameraPermissionsAsync();
+      setHasPermission(status === 'granted');
+    })();
+  }, []);
+
+  const takePhoto = async () => {
+    if (cameraRef.current) {
+      const photo: CameraCapturedPicture = await cameraRef.current.takePictureAsync();
+      const fileName = `${Date.now()}.jpg`;
+      const newPath = FileSystem.documentDirectory + fileName;
+      await FileSystem.moveAsync({ from: photo.uri, to: newPath });
+      setPhotoUri(newPath);
+    }
+  };
+
+  if (hasPermission === null) {
+    return (
+      <View style={styles.container}>
+        <Text>Requesting camera permission...</Text>
+      </View>
+    );
+  }
+  if (hasPermission === false) {
+    return (
+      <View style={styles.container}>
+        <Text>No access to camera</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {photoUri ? (
+        <Image source={{ uri: photoUri }} style={styles.preview} />
+      ) : (
+        <Camera style={styles.camera} ref={cameraRef} />
+      )}
+      <TouchableOpacity style={styles.button} onPress={takePhoto}>
+        <Text style={styles.buttonText}>Take Photo</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  camera: {
+    flex: 1,
+    aspectRatio: 3 / 4,
+    width: '100%',
+  },
+  preview: {
+    flex: 1,
+    width: '100%',
+    resizeMode: 'contain',
+  },
+  button: {
+    backgroundColor: '#2196F3',
+    padding: 10,
+    margin: 20,
+    borderRadius: 5,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+});

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,6 +12,8 @@
         "@expo/vector-icons": "^14.1.0",
         "@react-navigation/native": "^7.1.6",
         "expo": "~53.0.17",
+        "expo-camera": "^16.1.11",
+        "expo-file-system": "^18.1.11",
         "expo-font": "~13.3.2",
         "expo-linking": "~7.1.7",
         "expo-router": "~5.1.3",
@@ -5351,6 +5353,26 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "16.1.11",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-16.1.11.tgz",
+      "integrity": "sha512-etA5ZKoC6nPBnWWqiTmlX//zoFZ6cWQCCIdmpUHTGHAKd4qZNCkhPvBWbi8o32pDe57lix1V4+TPFgEcvPwsaA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-constants": {

--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,8 @@
     "@expo/vector-icons": "^14.1.0",
     "@react-navigation/native": "^7.1.6",
     "expo": "~53.0.17",
+    "expo-camera": "^16.1.11",
+    "expo-file-system": "^18.1.11",
     "expo-font": "~13.3.2",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.3",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3049,6 +3049,13 @@ expo-asset@~11.1.7:
     "@expo/image-utils" "^0.7.6"
     expo-constants "~17.1.7"
 
+expo-camera@^16.1.11:
+  version "16.1.11"
+  resolved "https://registry.npmjs.org/expo-camera/-/expo-camera-16.1.11.tgz"
+  integrity sha512-etA5ZKoC6nPBnWWqiTmlX//zoFZ6cWQCCIdmpUHTGHAKd4qZNCkhPvBWbi8o32pDe57lix1V4+TPFgEcvPwsaA==
+  dependencies:
+    invariant "^2.2.4"
+
 expo-constants@*, expo-constants@~17.1.7:
   version "17.1.7"
   resolved "https://registry.npmjs.org/expo-constants/-/expo-constants-17.1.7.tgz"
@@ -3057,7 +3064,7 @@ expo-constants@*, expo-constants@~17.1.7:
     "@expo/config" "~11.0.12"
     "@expo/env" "~1.0.7"
 
-expo-file-system@~18.1.11:
+expo-file-system@^18.1.11, expo-file-system@~18.1.11:
   version "18.1.11"
   resolved "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz"
   integrity sha512-HJw/m0nVOKeqeRjPjGdvm+zBi5/NxcdPf8M8P3G2JFvH5Z8vBWqVDic2O58jnT1OFEy0XXzoH9UqFu7cHg9DTQ==


### PR DESCRIPTION
## Summary
- install expo-camera and expo-file-system
- ignore Jest snapshots
- add a camera tab
- allow taking and saving photos to local storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ba4e43fa08328a40c217c1e6ad7c7